### PR TITLE
Add back comments lost since v3

### DIFF
--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -169,12 +169,12 @@
                         <head/>
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/mensural/mensural-sample164.txt" parse="text"/></egXML>
                      </figure> The same applies to the examples that follow.</p>
-                  <p>The following example illustrates an <hi rend="italic">imperfection</hi> (the two <hi rend="italic">longae</hi>) in <hi rend="italic">modus minor perfectus</hi> with the same <hi rend="italic">longa</hi>-<hi rend="italic">brevis</hi>-<hi rend="italic">brevis</hi>-<hi rend="italic">longa</hi> sequence but with an additional <hi rend="italic">dot of division</hi> between the two <hi rend="italic">breves</hi>. Notice that here the <hi rend="italic">longae</hi> have been imperfected, unlike the previous example in which they kept the perfect value indicated by the mensuration. <figure>
+                  <p>The following example illustrates an <hi rend="italic">imperfection</hi> (the two <hi rend="italic">longae</hi>) in <hi rend="italic">modus minor perfectus</hi> with the same <hi rend="italic">longa</hi>-<hi rend="italic">brevis</hi>-<hi rend="italic">brevis</hi>-<hi rend="italic">longa</hi> sequence but with an additional <hi rend="italic">dot of division</hi> between the two <hi rend="italic">breves</hi> (see <ptr target="#dots"/> for more details). Notice that here the <hi rend="italic">longae</hi> have been imperfected, unlike the previous example in which they kept the perfect value indicated by the mensuration. <figure>
                         <head/>
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/imperfection.mei" parse="text"/></egXML>
                      </figure>
                   </p>
-                  <p>The following example in <hi rend="italic">modus minor imperfectus</hi> illustrates the use of a dot of augmentation following the <hi rend="italic">longa</hi>. Notice that the <hi rend="italic">longa</hi>, which is supposed to be imperfect according to the mensuration, has a perfect value due to the augmentation dot. <figure>
+                  <p>The following example in <hi rend="italic">modus minor imperfectus</hi> illustrates the use of a dot of augmentation following the <hi rend="italic">longa</hi> (see <ptr target="#dots"/> for more details). Notice that the <hi rend="italic">longa</hi>, which is supposed to be imperfect according to the mensuration, has a perfect value due to the augmentation dot. <figure>
                         <head/>
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/augmentation.mei" parse="text"/></egXML>
                      </figure>
@@ -369,7 +369,7 @@
                         <specDesc key="att.stems.mensural" atts="stem.form"/>
                      </specList>
                   </p>
-                  <p>[place-holder for an example (image and code) of a note with one stem that includes many of these attributes]</p>
+                  <p>[include example (image and code) of a note with one stem that includes many of these attributes]</p>
                   <p>Sometimes notes have two stems. In this case, the <gi scheme="MEI">stem</gi> element can be used as a child of <gi scheme="MEI">note</gi> to define the individual characteristics of each stem with the following attributes:</p>
                   <p>
                      <specList>
@@ -382,7 +382,7 @@
                         <specDesc key="att.xy" atts="x y"/>
                      </specList>
                   </p>
-                  <p>[place-holder for an example (image and code) of a note with two stems]</p>
+                  <p>[include example (image and code) of a note with two stems]</p>
                </div>
                <div xml:id="plicas" type="div3">
                   <head>Plicas</head>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -417,7 +417,7 @@
                </div>
                <div xml:id="accidentals" type="div3">
                  <head>Accidentals</head>
-                 <p>[explain that accidentals are usually encoded as independent elemetns and that accid.ges can be used within notes]</p>
+                 <p>[explain that accidentals are usually encoded as independent elements and that accid.ges can be used within notes]</p>
                </div>
                <div xml:id="coloration" type="div3">
                  <head>Coloration</head>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -369,7 +369,7 @@
                         <specDesc key="att.stems.mensural" atts="stem.form"/>
                      </specList>
                   </p>
-                  <!-- PLACE-HOLDER FOR EXAMPLE OF ONE NOTE WITH ONE STEM: IMAGE and ITS ENCODING -->
+                  <p>[place-holder for an example (image and code) of a note with one stem that includes many of these attributes]</p>
                   <p>Sometimes notes have two stems. In this case, the <gi scheme="MEI">stem</gi> element can be used as a child of <gi scheme="MEI">note</gi> to define the individual characteristics of each stem with the following attributes:</p>
                   <p>
                      <specList>
@@ -382,7 +382,7 @@
                         <specDesc key="att.xy" atts="x y"/>
                      </specList>
                   </p>
-                  <!-- PLACE-HOLDER FOR EXAMPLE OF A NOTE WITH TWO STEMS: IMAGE and ITS ENCODING -->
+                  <p>[place-holder for an example (image and code) of a note with two stems]</p>
                </div>
                <div xml:id="plicas" type="div3">
                   <head>Plicas</head>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -404,7 +404,7 @@
                </div>
                <div xml:id="dots" type="div3">
                   <head>Dots</head>
-                  <p>Dots of division and augmentation can be encoded by using the <gi scheme="MEI">dot</gi> element. This element is meant to be used as a child of <gi scheme="MEI">layer</gi> following the <gi scheme="MEI">note</gi> or <gi scheme="MEI">rest</gi> after which it appears in the original source.</p> 
+                  <p>Dots of division and augmentation can be encoded by using the <gi scheme="MEI">dot</gi> element (provided by the MEI.shared module). This element is meant to be used as a child of <gi scheme="MEI">layer</gi> following the <gi scheme="MEI">note</gi> or <gi scheme="MEI">rest</gi> after which it appears in the original source.</p> 
                   <p>Dots in mensural notation are not encoded as children of notes or rests, but rather as a sibling of these. They are also not encoded as attributes (the use of the <att>dot</att> attribute in a <gi scheme="MEI">note</gi> or <gi scheme="MEI">rest</gi> elements is only acceptable in Common Music Notation, not mensural).</p>
                   <p>To indicate the nature of the dot (as a dot of division or augmentation), the <gi scheme="MEI">dot</gi> element has an attribute <att>form</att>, which can take on the following values:</p>
                   <list type="gloss">

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -415,6 +415,18 @@
                   </list>
                   The actual effect of these dots (<hi rend="italic">augmenting</hi> a note and making it perfect, or dividing a sequence of notes in different groupings by <hi rend="italic">imperfecting</hi> some notes or <hi rend="italic">altering</hi> others) is encoded with the <att>dur.quality</att> attribute of the correspoding <gi scheme="MEI">note</gi> elements. Examples of the use of dots of division and augmentation can be found in the <ptr target="#mensuralRules"/> section.
                </div>
+               <div xml:id="accidentals" type="div3">
+                 <head>Accidentals</head>
+                 <p>[explain that accidentals are usually encoded as independent elemetns and that accid.ges can be used within notes]</p>
+               </div>
+               <div xml:id="coloration" type="div3">
+                 <head>Coloration</head>
+                 <p>[explain where/how coloration can be encoded]</p>
+               </div>
+               <div xml:id="custos" type="div3">
+                 <head>Custos</head>
+                 <p>[explain that there is a custos element available]</p>
+               </div>
             </div>
          </div>
       </body>


### PR DESCRIPTION
Add back commented sections indicating future work. As Anna Plaksin (Mensural IG co-chair) indicated, this information was useful for people to know how accidentals, custos, and coloration work in general or that they are available somewhere in the schema (even if full details are not provided yet). These sections have to be filled out later, but the fact that they exist helps people to have an idea of what is available in the schema and also helps us to allow others to contribute to the guidelines by filling in these sections.

I also used the same style for commenting on places where examples are expected to be provided by the musicologists of the community.